### PR TITLE
Fix CLI 'command not found' after pip install: add `python -m trustmodel` + PATH note

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ trustmodel login          # free account → API key + 5 credits ($500). No cred
 trustmodel eval "Take 500mg of metformin twice daily."
 ```
 
+> **`trustmodel: command not found`?** `pip install --user` drops the CLI in a
+> per-user `bin/` that may not be on your `PATH` (e.g. `~/.local/bin` on Linux,
+> `~/Library/Python/3.x/bin` on macOS). Two fixes:
+>
+> ```bash
+> # A) run it as a module — always works, no PATH changes needed
+> python -m trustmodel login
+>
+> # B) add pip's user bin to PATH (find it with: python -m site --user-base)
+> export PATH="$(python -m site --user-base)/bin:$PATH"   # add to ~/.zshrc or ~/.bashrc
+> ```
+>
+> Installing into a virtualenv (`python -m venv .venv && source .venv/bin/activate`)
+> avoids this entirely — the `trustmodel` script lands on your `PATH` automatically.
+
 ```text
 🔴 TrustScore: 41/100  (Grade D)  [local]
    safety          ██········    18  ⚠

--- a/src/trustmodel/__main__.py
+++ b/src/trustmodel/__main__.py
@@ -1,0 +1,15 @@
+"""Enable `python -m trustmodel ...` as a PATH-independent fallback for the CLI.
+
+If the `trustmodel` console script isn't on your PATH (common with
+`pip install --user`), you can always invoke the same CLI via the module form:
+
+    python -m trustmodel login
+    python -m trustmodel eval "some AI output"
+"""
+
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

A dev did `pip install trustmodel` but `trustmodel login` failed from his CLI. Root cause is **not** auth — it's the classic pip user-install gap: the `trustmodel` console script lands in a per-user `bin/` (`~/.local/bin` on Linux, `~/Library/Python/3.x/bin` on macOS) that often isn't on `PATH`, so the shell reports *command not found*. The usual fallback, `python -m trustmodel`, **also** failed because the package had no `__main__.py`.

## Fix

- **`src/trustmodel/__main__.py`** — `python -m trustmodel ...` now works as a PATH-independent way to run the exact same CLI (`login`, `eval`, `govern`, …). Previously errored: `No module named trustmodel.__main__`.
- **README** — added a *"command not found?"* note under the quickstart with the module form and a one-liner to put pip's user bin on `PATH` (`python -m site --user-base`), plus the venv recommendation.

## Verification

```
$ python -m trustmodel --version
trustmodel 0.1.0
$ python -m trustmodel policies      # works end-to-end
$ python -m pytest -q
6 passed
```

No behavior change to the existing console script; this only adds a fallback entrypoint and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)