### PR TITLE
TRUS-1082: Cross-link the TrustModel MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,17 @@ Mapped to **EU AI Act, NIST AI RMF, ISO 42001, NYC Local Law 144, OWASP LLM Top 
 | Time to first result | **30 sec** | minutes | weeks |
 | Cost | free + $500 credits | free | $15k+ |
 
+## MCP server
+
+Use TrustModel from any [Model Context Protocol](https://modelcontextprotocol.io/) client (Claude Code, Cursor, Windsurf, Claude Desktop) — evaluate, score, govern, and run end-to-end agentic trace evaluation as agent tools.
+
+- **Repo:** [`karlmehta/trustmodel-mcp`](https://github.com/karlmehta/trustmodel-mcp)
+- **npm:** [`@trustmodel/mcp-server`](https://www.npmjs.com/package/@trustmodel/mcp-server)
+
+```bash
+claude mcp add trustmodel --env TRUSTMODEL_API_KEY=tm-... -- npx -y @trustmodel/mcp-server
+```
+
 ## Open core (Linux → Red Hat)
 
 This toolkit is **MIT-licensed** and free. The **calibrated hosted TrustScore**, PDF compliance


### PR DESCRIPTION
**Epic:** TRUS-1081 · **Ticket:** TRUS-1082 (MCP-1)

Adds an **MCP server** section to the OSS README linking [`karlmehta/trustmodel-mcp`](https://github.com/karlmehta/trustmodel-mcp) and the npm package `@trustmodel/mcp-server`, with a one-line `claude mcp add` install. Completes the CLI · SDK · MCP cross-linking from the quick-wins ticket.

Docs only.