### PR TITLE
TRUS-1089: Python MCP server (FastMCP) — no-key local eval/govern + cloud score

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,49 @@ Mapped to **EU AI Act, NIST AI RMF, ISO 42001, NYC Local Law 144, OWASP LLM Top 
 | Time to first result | **30 sec** | minutes | weeks |
 | Cost | free + $500 credits | free | $15k+ |
 
+## MCP server — use TrustModel from any agent
+
+Expose Eval and Govern to any [Model Context Protocol](https://modelcontextprotocol.io/) client (Claude Code, Cursor, Claude Desktop, …). **Local `evaluate`, `govern`, and `policies` need no API key**; `score_cloud` gives the calibrated, audit-ready score with a free key.
+
+```bash
+pip install "trustmodel[mcp]"
+trustmodel-mcp        # or:  trustmodel mcp   — runs the server on stdio
+```
+
+Zero-install with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uvx --from "trustmodel[mcp]" trustmodel-mcp
+```
+
+Register it with Claude Code:
+
+```bash
+claude mcp add trustmodel -- uvx --from "trustmodel[mcp]" trustmodel-mcp
+```
+
+Or add to Claude Desktop / Cursor (`claude_desktop_config.json` / `.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "trustmodel": {
+      "command": "uvx",
+      "args": ["--from", "trustmodel[mcp]", "trustmodel-mcp"]
+    }
+  }
+}
+```
+
+| Tool | Key? | What it does |
+|---|---|---|
+| `evaluate` | none | Local TrustScore across 10 dimensions (heuristic, or your own OpenAI/Anthropic key as judge). |
+| `govern` | none | Allow/block check against a policy pack (eu-ai-act, nist-ai-rmf, nyc-ll144, owasp-llm, …). |
+| `policies` | none | List built-in policy packs. |
+| `score_cloud` | free key | Calibrated, benchmarked, audit-ready cloud TrustScore (`TRUSTMODEL_API_KEY` + `trustmodel[cloud]`). |
+
+> The `mcp` extra requires Python ≥ 3.10. There's also a TypeScript MCP server — [`@trustmodel/mcp-server`](https://www.npmjs.com/package/@trustmodel/mcp-server) ([repo](https://github.com/karlmehta/trustmodel-mcp)).
+
 ## Open core (Linux → Red Hat)
 
 This toolkit is **MIT-licensed** and free. The **calibrated hosted TrustScore**, PDF compliance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ openai = ["openai>=1.0"]
 anthropic = ["anthropic>=0.30"]
 telemetry = ["opentelemetry-sdk>=1.20", "opentelemetry-api>=1.20"]
 cloud = ["requests>=2.28"]
-all = ["openai>=1.0", "anthropic>=0.30", "opentelemetry-sdk>=1.20", "opentelemetry-api>=1.20", "requests>=2.28"]
+mcp = ["mcp>=1.2"]
+all = ["openai>=1.0", "anthropic>=0.30", "opentelemetry-sdk>=1.20", "opentelemetry-api>=1.20", "requests>=2.28", "mcp>=1.2"]
 dev = ["pytest>=7.0", "ruff>=0.4"]
 
 [project.urls]
@@ -42,6 +43,7 @@ Demo = "https://huggingface.co/spaces/karlmehta/trustmodel-score-any-ai"
 
 [project.scripts]
 trustmodel = "trustmodel.cli:main"
+trustmodel-mcp = "trustmodel.mcp_server:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/trustmodel"]

--- a/src/trustmodel/cli.py
+++ b/src/trustmodel/cli.py
@@ -119,6 +119,21 @@ def _cmd_monitor(args):
     return 0
 
 
+def _cmd_mcp(args):
+    try:
+        from .mcp_server import run
+    except ImportError:
+        print(
+            "The MCP server needs the 'mcp' extra:\n\n"
+            '    pip install "trustmodel[mcp]"\n\n'
+            "Then run `trustmodel mcp` (or `trustmodel-mcp`) and point your MCP client at it.",
+            file=sys.stderr,
+        )
+        return 2
+    run()
+    return 0
+
+
 def _cmd_policies(args):
     from .govern import available_policies
     print("Built-in policy packs:")
@@ -163,6 +178,9 @@ def main(argv=None):
 
     p_pol = sub.add_parser("policies", help="list built-in policy packs")
     p_pol.set_defaults(func=_cmd_policies)
+
+    p_mcp = sub.add_parser("mcp", help="run the MCP server (stdio) for MCP clients")
+    p_mcp.set_defaults(func=_cmd_mcp)
 
     args = parser.parse_args(argv)
     if not getattr(args, "command", None):

--- a/src/trustmodel/eval.py
+++ b/src/trustmodel/eval.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Iterable, List, Optional
 
-from .auth import require_api_key
+from .auth import get_api_key, require_api_key
 from .dimensions import BY_KEY, DIMENSION_KEYS, grade
 from .judges import DimensionScore, Judge, get_default_judge
 
@@ -61,9 +61,12 @@ def _severity(value: float) -> str:
 class LocalEvaluator:
     """Evaluate AI output locally with an LLM-as-judge (or heuristic fallback)."""
 
-    def __init__(self, judge: Optional[Judge] = None, prefer: Optional[str] = None):
-        # All three products require a free TrustModel account/API key (grants 5 credits / $500).
-        self.api_key = require_api_key()
+    def __init__(self, judge: Optional[Judge] = None, prefer: Optional[str] = None,
+                 require_key: bool = True):
+        # Calibrated/cloud scoring needs a free TrustModel key (grants 5 credits / $500).
+        # Local BYO-LLM/heuristic scoring can run keyless (require_key=False) — this powers
+        # the no-key local tier (the MCP server's local tools).
+        self.api_key = require_api_key() if require_key else get_api_key()
         self.judge = judge or get_default_judge(prefer=prefer)
 
     def evaluate(

--- a/src/trustmodel/govern.py
+++ b/src/trustmodel/govern.py
@@ -29,7 +29,7 @@ from typing import List, Optional
 
 import yaml
 
-from .auth import require_api_key
+from .auth import get_api_key, require_api_key
 from .eval import LocalEvaluator
 
 _PACKS_DIR = Path(__file__).parent / "policy_packs"
@@ -76,9 +76,11 @@ class Guardrail:
     """Evaluate output against a policy pack and decide allow/block."""
 
     def __init__(self, policy: str = "eu-ai-act", evaluator: Optional[LocalEvaluator] = None,
-                 block_severity: str = "high"):
-        # Govern requires a free TrustModel account/API key (grants 5 credits / $500).
-        self.api_key = require_api_key()
+                 block_severity: str = "high", require_key: bool = True):
+        # Govern needs a free TrustModel key for calibrated/cloud use. Local policy
+        # checks can run keyless (require_key=False) — this powers the no-key local tier.
+        self.api_key = require_api_key() if require_key else get_api_key()
+        self._require_key = require_key
         self.policy_id = policy
         self.pack = load_policy(policy)
         self.rules = self.pack.get("rules", [])
@@ -89,7 +91,7 @@ class Guardrail:
     @property
     def evaluator(self) -> LocalEvaluator:
         if self._evaluator is None:
-            self._evaluator = LocalEvaluator()
+            self._evaluator = LocalEvaluator(require_key=self._require_key)
         return self._evaluator
 
     def check(self, output: str, context: Optional[str] = None) -> GuardrailVerdict:

--- a/src/trustmodel/mcp_server.py
+++ b/src/trustmodel/mcp_server.py
@@ -1,0 +1,129 @@
+"""TrustModel MCP server.
+
+Exposes the TrustModel engine to any Model Context Protocol client (Claude Code,
+Cursor, Claude Desktop, …) as agent tools — built on the official MCP Python SDK
+(FastMCP). Wraps the existing local engine; no scoring is reimplemented here.
+
+Tools:
+  * evaluate(output, context)        — local TrustScore across 10 dimensions. NO key.
+  * govern(text, policy, context)    — policy-pack allow/block check. NO key.
+  * policies()                       — list built-in policy packs. NO key.
+  * score_cloud(output, context)     — calibrated, audit-ready cloud TrustScore.
+                                       Needs a free TRUSTMODEL_API_KEY; degrades
+                                       gracefully (never crashes) if absent.
+
+Run:
+    pip install "trustmodel[mcp]"
+    trustmodel-mcp                 # or:  trustmodel mcp
+    uvx --from "trustmodel[mcp]" trustmodel-mcp
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from .eval import LocalEvaluator
+from .govern import Guardrail, available_policies
+
+mcp = FastMCP("trustmodel")
+
+_LOCAL_NOTE = (
+    "local score — uncalibrated (heuristic, or your own OpenAI/Anthropic key as judge). "
+    "For a calibrated, benchmarked, audit-ready TrustScore call score_cloud with a free "
+    "TRUSTMODEL_API_KEY (https://trustmodel.ai/signup)."
+)
+
+
+@mcp.tool()
+def evaluate(output: str, context: Optional[str] = None) -> dict:
+    """Score AI output locally across the 10 TrustModel dimensions (safety, fairness,
+    accuracy, privacy, transparency, robustness, accountability, explainability,
+    compliance, reliability) and roll it into a 0-100 TrustScore.
+
+    No API key required — runs on your machine. Uses your OPENAI_API_KEY /
+    ANTHROPIC_API_KEY as the judge if available, otherwise a transparent heuristic
+    fallback. Returns trust_score, grade, per-dimension scores, and violations."""
+    result = LocalEvaluator(require_key=False).evaluate(output, context=context)
+    data = result.to_dict()
+    data["note"] = _LOCAL_NOTE
+    return data
+
+
+@mcp.tool()
+def govern(text: str, policy: str = "eu-ai-act", context: Optional[str] = None) -> dict:
+    """Check text against a governance policy pack and decide allow/block.
+
+    No API key required. `policy` is a built-in pack id (e.g. eu-ai-act, nist-ai-rmf,
+    nyc-ll144, owasp-llm — call policies() to list them) or a path to a custom .yaml
+    pack. Returns allowed/blocked, the policy id, and the list of rule violations."""
+    gr = Guardrail(policy=policy, require_key=False)
+    verdict = gr.check(text, context=context)
+    return {
+        "allowed": verdict.allowed,
+        "blocked": verdict.blocked,
+        "policy": verdict.policy,
+        "violations": [v.__dict__ for v in verdict.violations],
+        "note": _LOCAL_NOTE,
+    }
+
+
+@mcp.tool()
+def policies() -> dict:
+    """List the built-in governance policy packs available to govern()."""
+    return {"available_policies": available_policies()}
+
+
+@mcp.tool()
+def score_cloud(output: str, context: Optional[str] = None) -> dict:
+    """Calibrated, benchmarked, audit-ready cloud TrustScore.
+
+    Requires a free TRUSTMODEL_API_KEY (5 free credits / $500) and the cloud extra
+    (pip install "trustmodel[cloud]"). If either is missing this returns a clear
+    upgrade message instead of raising — local evaluate/govern always work with no key."""
+    try:
+        from .cloud import CloudClient  # noqa: F401
+    except ImportError:
+        return _cloud_unavailable("the TrustModel cloud client could not be imported")
+
+    try:
+        client = CloudClient()
+    except Exception as e:  # AuthError when no key is set
+        return _cloud_unavailable(str(e))
+
+    try:
+        data = client.evaluate(output, context=context)
+        if isinstance(data, dict):
+            data.setdefault("calibrated", True)
+            return data
+        return {"calibrated": True, "result": data}
+    except Exception as e:  # CloudUnavailable, network/HTTP errors, missing requests extra
+        return _cloud_unavailable(str(e))
+
+
+def _cloud_unavailable(reason: str) -> dict:
+    return {
+        "calibrated": False,
+        "error": "calibrated cloud scoring is unavailable",
+        "reason": reason,
+        "hint": (
+            "Set TRUSTMODEL_API_KEY (free, 5 credits) — get one at "
+            "https://trustmodel.ai/signup — and install the cloud extra: "
+            'pip install "trustmodel[cloud]". Local evaluate/govern need no key.'
+        ),
+    }
+
+
+def run() -> None:
+    """Start the MCP server on stdio (the default MCP transport)."""
+    mcp.run()
+
+
+def main() -> None:
+    """Console-script entry point (`trustmodel-mcp`)."""
+    run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,53 @@
+"""Smoke tests for the MCP server tool handlers.
+
+These exercise the FastMCP tool functions directly (no transport) and prove the
+no-key local tier works: evaluate/govern/policies need no API key, and score_cloud
+degrades gracefully when no key is set. Skipped if the optional `mcp` extra
+(pip install "trustmodel[mcp]") is not installed.
+"""
+
+import pytest
+
+pytest.importorskip("mcp", reason="requires the 'mcp' extra: pip install \"trustmodel[mcp]\"")
+
+from trustmodel import mcp_server  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_key(monkeypatch):
+    """Run every test as if no TrustModel API key is available anywhere."""
+    monkeypatch.delenv("TRUSTMODEL_API_KEY", raising=False)
+    import trustmodel.auth as auth
+    monkeypatch.setattr(auth, "_read_saved", lambda: None)
+
+
+def test_evaluate_works_with_no_key():
+    data = mcp_server.evaluate("The capital of France is Paris.")
+    assert 0 <= data["trust_score"] <= 100
+    assert data["grade"] in {"A", "B", "C", "D", "F"}
+    assert len(data["dimensions"]) == 10
+    assert data["calibrated"] is False
+    assert "note" in data
+
+
+def test_govern_works_with_no_key():
+    data = mcp_server.govern(
+        "Based on your resume you're not a culture fit. We can't share why.",
+        policy="nyc-ll144",
+    )
+    assert data["blocked"] is True
+    assert data["policy"] == "nyc-ll144"
+    assert any(v["severity"] == "high" for v in data["violations"])
+
+
+def test_policies_lists_packs():
+    data = mcp_server.policies()
+    for expected in ("eu-ai-act", "owasp-llm", "nist-ai-rmf", "nyc-ll144"):
+        assert expected in data["available_policies"]
+
+
+def test_score_cloud_degrades_without_key():
+    data = mcp_server.score_cloud("The capital of France is Paris.")
+    assert data["calibrated"] is False
+    assert "error" in data
+    assert "hint" in data  # never crashes — returns guidance instead


### PR DESCRIPTION
**Epic:** TRUS-1081 · **Ticket:** TRUS-1089 (MCP-3) · on the critical path (1 → **3** → 6 → 7)

NEW Python MCP server wrapping the existing local engine — the fastest no-key win. Reuses `LocalEvaluator`, `Guardrail`, and the policy packs; **no scoring is reimplemented**.

## Tools
| Tool | Key? | What |
|---|---|---|
| `evaluate` | none | Local TrustScore across 10 dimensions (heuristic, or your OpenAI/Anthropic key as judge). |
| `govern` | none | Allow/block against a policy pack (eu-ai-act, nist-ai-rmf, nyc-ll144, owasp-llm). |
| `policies` | none | List built-in packs. |
| `score_cloud` | free key | Calibrated cloud TrustScore; degrades gracefully (never crashes) if no key / no `[cloud]`. |

## Changes
- **`trustmodel/mcp_server.py`** (new): FastMCP server on stdio (official `mcp` SDK).
- **`eval.py` / `govern.py`**: additive `require_key` flag — **default `True` preserves existing behavior**; local tier passes `require_key=False` to run keyless. (Today both hard-require a key in their constructors, which is what blocked a no-key local tier.)
- **`cli.py`**: `trustmodel mcp` subcommand.
- **`pyproject.toml`**: `[mcp]` extra (`mcp>=1.2`) + `trustmodel-mcp` console script. (The extra needs Python ≥ 3.10; base package stays 3.9+.)
- **README**: MCP server section — `pip install "trustmodel[mcp]"`, `uvx` one-liner, Claude Desktop/Cursor config.
- **`tests/test_mcp_server.py`**: keyless smoke + graceful cloud-degrade (skips if `mcp` not installed).

## Verification (Python 3.13 venv)
- `pip install -e ".[mcp,dev]"` ✅
- `pytest` → **10 passed** (6 original + 4 new)
- End-to-end stdio handshake: `initialize` → `tools/list` returns the 4 tools → `evaluate` returns a score **with no API key** → `score_cloud` returns guidance instead of crashing.