### PR TITLE
TRUS-1086: PyPI + MCP Registry artifacts for the Python MCP server

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,39 @@
+# Publishing `trustmodel` (PyPI) + the Python MCP server to the MCP Registry
+
+The Python MCP server ships inside the `trustmodel` PyPI package (the `[mcp]`
+extra + the `trustmodel-mcp` console script). It is listed in the official MCP
+Registry under the GitHub-OAuth namespace `io.github.karlmehta/trustmodel-mcp-py`.
+**No DNS / no Cloudflare.**
+
+Ownership is proved by the `<!-- mcp-name: io.github.karlmehta/trustmodel-mcp-py -->`
+comment at the top of this README (which becomes the PyPI long-description) — it
+must match the `name` in `server.json`.
+
+## 1. Publish to PyPI
+
+Requires PyPI auth (a project API token in `~/.pypirc` or `TWINE_*`).
+
+```bash
+python -m pip install --upgrade build twine
+python -m build                      # builds sdist + wheel for trustmodel 0.2.0
+python -m twine upload dist/*        # publishes to PyPI
+```
+
+Verify: `pip install "trustmodel[mcp]"` then `trustmodel-mcp` starts the server;
+`pip index versions trustmodel` shows `0.2.0`.
+
+## 2. Publish to the official MCP Registry
+
+```bash
+mcp-publisher login github           # interactive GitHub OAuth → verifies io.github.karlmehta
+mcp-publisher publish                # reads ./server.json
+```
+
+Verify:
+
+```bash
+curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=trustmodel" | jq '.servers[].name'
+# expect both io.github.karlmehta/trustmodel-mcp (npm) and .../trustmodel-mcp-py (pypi)
+```
+
+The npm/TypeScript counterpart publishes from `karlmehta/trustmodel-mcp`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- mcp-name: io.github.karlmehta/trustmodel-mcp-py -->
 <div align="center">
 
 <img src="assets/trustmodel-icon.png" alt="TrustModel" width="92" />

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "trustmodel"
-version = "0.1.0"
+version = "0.2.0"
 description = "Score any AI for trust in 30 seconds. Open-source eval, monitoring, and governance across 10 trust dimensions — no API key required."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.karlmehta/trustmodel-mcp-py",
+  "description": "Python MCP server for TrustModel — local no-key TrustScore across 10 dimensions, policy-pack governance, and calibrated cloud scoring. Reuses the open-source trustmodel engine.",
+  "version": "0.2.0",
+  "repository": {
+    "url": "https://github.com/karlmehta/trustmodel",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "trustmodel",
+      "version": "0.2.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "TRUSTMODEL_API_KEY",
+          "description": "TrustModel API key (free — 5 credits / $500 at https://trustmodel.ai/signup) for calibrated cloud scoring. Optional: local evaluate/govern/policies work without it.",
+          "isRequired": false,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}

--- a/src/trustmodel/__init__.py
+++ b/src/trustmodel/__init__.py
@@ -29,7 +29,7 @@ from .govern import (
 )
 from .dimensions import DIMENSION_KEYS, DIMENSIONS
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
**Epic:** TRUS-1081 · **Ticket:** TRUS-1086 (MCP-6, PyPI side)

Prepares the official MCP Registry listing for the **Python** MCP server under `io.github.karlmehta/trustmodel-mcp-py`. **No DNS / Cloudflare.**

- README: `<!-- mcp-name: io.github.karlmehta/trustmodel-mcp-py -->` ownership comment (matches `server.json` name).
- `server.json`: official registry entry (schema 2025-12-11) — pypi `trustmodel`, stdio, key optional.
- Version bump `0.1.0 → 0.2.0` (pyproject + `__init__`) for the release that ships the MCP server.
- `PUBLISHING.md`: `build`/`twine upload` + `mcp-publisher` steps.

`pytest` → 10 passed. **Publishes are a credentialed maintainer step** (PyPI token + mcp-publisher GitHub OAuth) — not run here.

> npm counterpart: pdxlab/trustmodel-mcp-server #23.