### PR TITLE
MCP-9: Conversion/upsell gating (Python MCP server)

### DIFF
--- a/src/trustmodel/cloud.py
+++ b/src/trustmodel/cloud.py
@@ -19,6 +19,19 @@ class CloudUnavailable(Exception):
     pass
 
 
+# Gateway credit-exhaustion response codes (HTTP 403). See sdk/middleware.py.
+_EXHAUSTION_CODES = {"api_key_credits_exhausted", "subscription_credits_exhausted"}
+
+
+class CreditsExhausted(CloudUnavailable):
+    """Raised when the account's free/plan credits are used up — a conversion
+    moment (register/upgrade), not a transient failure."""
+
+    def __init__(self, detail: Optional[dict] = None):
+        self.detail = detail or {}
+        super().__init__(self.detail.get("detail", "TrustModel credits exhausted."))
+
+
 class CloudClient:
     """Thin client for calibrated cloud scoring (pip install 'trustmodel[cloud]')."""
 
@@ -46,8 +59,19 @@ class CloudClient:
                 json={"output": output, "context": context, "model_type": "chat"},
                 timeout=45,
             )
+            # Credit exhaustion is a conversion moment — surface it distinctly so
+            # callers can show an upgrade CTA rather than a generic failure.
+            if r.status_code == 403:
+                try:
+                    body = r.json()
+                except Exception:  # noqa: BLE001
+                    body = {}
+                if body.get("code") in _EXHAUSTION_CODES:
+                    raise CreditsExhausted(body)
             r.raise_for_status()
             return r.json()
+        except CreditsExhausted:
+            raise
         except Exception as e:  # noqa: BLE001
             raise CloudUnavailable(
                 f"Cloud scoring unavailable ({e}). Falling back to local scoring is "

--- a/src/trustmodel/mcp_server.py
+++ b/src/trustmodel/mcp_server.py
@@ -29,11 +29,33 @@ from .govern import Guardrail, available_policies
 
 mcp = FastMCP("trustmodel")
 
+SIGNUP_URL = "https://trustmodel.ai/signup"
+PRICING_URL = "https://trustmodel.ai/pricing"
+
 _LOCAL_NOTE = (
     "local score — uncalibrated (heuristic, or your own OpenAI/Anthropic key as judge). "
     "For a calibrated, benchmarked, audit-ready TrustScore call score_cloud with a free "
     "TRUSTMODEL_API_KEY (https://trustmodel.ai/signup)."
 )
+
+
+def _local_tier() -> dict:
+    """Conversion gating (TRUS-1090): label local results as uncalibrated /
+    not-audit-ready and carry a register CTA — the value asymmetry that drives signup."""
+    return {
+        "tier": "local",
+        "calibrated": False,
+        "audit_ready": False,
+        "upgrade": {
+            "message": (
+                "Local, uncalibrated score — fine for quick checks, not for production "
+                "or audit. Register for a free TrustModel key (5 credits / $500) for a "
+                "calibrated, audit-ready TrustScore via score_cloud."
+            ),
+            "register_url": SIGNUP_URL,
+        },
+        "note": _LOCAL_NOTE,
+    }
 
 
 @mcp.tool()
@@ -47,7 +69,7 @@ def evaluate(output: str, context: Optional[str] = None) -> dict:
     fallback. Returns trust_score, grade, per-dimension scores, and violations."""
     result = LocalEvaluator(require_key=False).evaluate(output, context=context)
     data = result.to_dict()
-    data["note"] = _LOCAL_NOTE
+    data.update(_local_tier())
     return data
 
 
@@ -65,7 +87,7 @@ def govern(text: str, policy: str = "eu-ai-act", context: Optional[str] = None) 
         "blocked": verdict.blocked,
         "policy": verdict.policy,
         "violations": [v.__dict__ for v in verdict.violations],
-        "note": _LOCAL_NOTE,
+        **_local_tier(),
     }
 
 
@@ -83,7 +105,7 @@ def score_cloud(output: str, context: Optional[str] = None) -> dict:
     (pip install "trustmodel[cloud]"). If either is missing this returns a clear
     upgrade message instead of raising — local evaluate/govern always work with no key."""
     try:
-        from .cloud import CloudClient  # noqa: F401
+        from .cloud import CloudClient, CreditsExhausted  # noqa: F401
     except ImportError:
         return _cloud_unavailable("the TrustModel cloud client could not be imported")
 
@@ -98,8 +120,26 @@ def score_cloud(output: str, context: Optional[str] = None) -> dict:
             data.setdefault("calibrated", True)
             return data
         return {"calibrated": True, "result": data}
+    except CreditsExhausted as e:
+        return _credits_exhausted(e.detail)
     except Exception as e:  # CloudUnavailable, network/HTTP errors, missing requests extra
         return _cloud_unavailable(str(e))
+
+
+def _credits_exhausted(detail: dict) -> dict:
+    """Conversion moment (TRUS-1090): free/plan credits used up → upgrade CTA."""
+    return {
+        "calibrated": False,
+        "error": "credits_exhausted",
+        "tier": "cloud",
+        "message": (
+            "You've used all your free TrustModel credits. Upgrade to keep scoring in "
+            "production — buy credits or move to a plan with continuous monitoring, signed "
+            "audit reports, and dashboards. Local evaluate/govern remain available."
+        ),
+        "upgrade_url": PRICING_URL,
+        "detail": detail,
+    }
 
 
 def _cloud_unavailable(reason: str) -> dict:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -51,3 +51,25 @@ def test_score_cloud_degrades_without_key():
     assert data["calibrated"] is False
     assert "error" in data
     assert "hint" in data  # never crashes — returns guidance instead
+
+
+def test_local_results_carry_register_cta():
+    """Conversion gating: local results are labelled uncalibrated/not-audit-ready
+    and carry a register CTA (drives signup)."""
+    data = mcp_server.evaluate("hello")
+    assert data["tier"] == "local"
+    assert data["audit_ready"] is False
+    assert data["upgrade"]["register_url"]
+
+    gov = mcp_server.govern("hello", policy="eu-ai-act")
+    assert gov["tier"] == "local"
+    assert gov["upgrade"]["register_url"]
+
+
+def test_credit_exhaustion_returns_upgrade_cta():
+    """When the gateway reports exhausted credits, score_cloud returns an upgrade
+    CTA (the paid upsell moment) — verified via the helper."""
+    out = mcp_server._credits_exhausted({"code": "api_key_credits_exhausted", "credits_used": 5})
+    assert out["error"] == "credits_exhausted"
+    assert out["upgrade_url"]
+    assert out["tier"] == "cloud"


### PR DESCRIPTION
**Epic:** TRUS-1081 · **Ticket:** TRUS-1090 (MCP-9) · sibling of pdxlab/trustmodel-mcp-server #25

Wires the free→register→upgrade funnel into the Python MCP server.

- **`cloud.py`:** new `CreditsExhausted` exception; `CloudClient.evaluate` detects the gateway's 403 (`api_key_credits_exhausted` / `subscription_credits_exhausted`) and raises it distinctly instead of a generic failure.
- **`mcp_server.py`:** local `evaluate`/`govern` stamp `tier: local`, `calibrated/audit_ready: false` + `register_url` CTA (drives signup); `score_cloud` maps `CreditsExhausted` → an `upgrade_url` CTA (the paid upsell moment).
- Tests for both. **12 pytest pass.**